### PR TITLE
Update documentation to include React support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,106 @@ This library parses your Grafana dashboard JSON, extracts the configuration for 
 This means you can define your charts in Grafana and render them anywhere!
 ## Features
 
-   * **Render Entire Dashboards**: Use the `<GrafanaDashboard>` Svelte component to render a full dashboard grid.
+   * **Render Entire Dashboards**: Use the `<GrafanaDashboard>` Svelte or React component to render a full dashboard grid.
    * **Framework-Agnostic Core**: Use the core rendering engine in any JavaScript project.
-   * **SvelteKit Adapter**: Get up and running in SvelteKit in minutes with the `<GrafanaPanel>` component.
+   * **Svelte and React Adapters**: Get up and running in SvelteKit or React in minutes with the `<GrafanaPanel>` component.
    * **Type-Safe**: Written entirely in TypeScript.
    * **Dynamic Data**: Charts are connected directly to your Prometheus datasource.
    * **Reusable Logic**: Don't repeat your PromQL queries and chart configurations.
 
 ## Installation
 
-First, you need the core library and the adapter for your framework of choice. For now, only SvelteKit is officially supported.
+First, you need the core library and the adapter for your framework of choice. Svelte and React are officially supported.
 
 You will also need to install Chart.js and its Prometheus plugin, which are peer dependencies.
 
 ```
 npm install chart.js chartjs-adapter-date-fns date-fns chartjs-plugin-datasource-prometheus
+```
+
+Then, install the core library and the adapter for your framework:
+
+**Svelte**
+```
 npm install @leafcuttr/libgraphit-core @leafcuttr/libgraphit-svelte
+```
+
+**React**
+```
+npm install @leafcuttr/libgraphit-core @leafcuttr/libgraphit-react
+```
+
+## Usage with React
+
+There are two primary ways to use the React adapter: rendering a full dashboard or rendering a single panel.
+
+### Rendering a Full Dashboard
+
+The easiest way to get started is to render an entire dashboard. The `GrafanaDashboard` component will handle the layout and render all panels.
+
+  *  **Get your Grafana Dashboard JSON**:
+     - In Grafana, go to your dashboard settings (the cog icon).
+     - Select "JSON Model" from the side menu.
+     - Copy the entire JSON object and save it as a `.json` file in your project.
+
+  *  **Use the component in your `.tsx` file**:
+
+```tsx
+import { GrafanaDashboard } from '@leafcuttr/libgraphit-react';
+import type { GrafanaDashboard as GrafanaDashboardType } from '@leafcuttr/libgraphit-core';
+import dashboardJson from './your-dashboard.json';
+import './App.css';
+
+const PROMETHEUS_URL = 'http://localhost:9090';
+
+function App() {
+  return (
+    <div>
+      <h1>My Application Dashboard</h1>
+      <p>This entire dashboard is defined in Grafana but rendered here with React and Chart.js!</p>
+      <GrafanaDashboard
+        dashboardJson={dashboardJson as GrafanaDashboardType}
+        prometheusUrl={PROMETHEUS_URL}
+        theme="dark"
+      />
+    </div>
+  );
+}
+
+export default App;
+```
+
+### Rendering a Single Panel
+
+If you only need a single panel from a dashboard, you can use the `GrafanaPanel` component.
+
+  *  **Get your Panel JSON**: Follow the steps above to get the dashboard JSON, then find the specific panel you want in the `panels` array and extract its JSON object.
+
+  *  **Use the component in your `.tsx` file**:
+
+```tsx
+import { GrafanaPanel } from '@leafcuttr/libgraphit-react';
+import type { Panel } from '@leafcuttr/libgraphit-core';
+import dashboardJson from './your-dashboard.json';
+import './App.css';
+
+const PROMETHEUS_URL = 'http://localhost:9090';
+const panelJson = dashboardJson.panels.find(p => p.title === 'My Awesome Panel') as Panel | undefined;
+
+function App() {
+  return (
+    <div style={{ width: '80%', height: '400px', margin: 'auto' }}>
+      {panelJson ? (
+        <GrafanaPanel
+          panelJson={panelJson}
+          prometheusUrl={PROMETHEUS_URL}
+        />
+      ) : (
+        <p>Panel configuration not found.</p>
+      )}
+    </div>
+  );
+}
 ```
 
 ## Usage with SvelteKit
@@ -104,7 +188,9 @@ The library consists of two main parts:
 
 * @leafcuttr/libgraphit-svelte: A thin wrapper that provides Svelte components (`<GrafanaDashboard>` and `<GrafanaPanel>`) to make integration with Svelte's lifecycle seamless.
 
-This architecture allows for new adapters (e.g., for React or Vue) to be built on top of the same core engine.
+* @leafcuttr/libgraphit-react: A thin wrapper that provides React components (`<GrafanaDashboard>` and `<GrafanaPanel>`) to make integration with React's lifecycle seamless.
+
+This architecture allows for new adapters (e.g., for Vue) to be built on top of the same core engine.
 Current Limitations
 
   * **Panel Support**: Currently, `timeseries`, `graph`, `stat`, `gauge`, and `table` panels are supported. Community contributions for other panel types are welcome.

--- a/docs/HighlevelDesign.md
+++ b/docs/HighlevelDesign.md
@@ -4,7 +4,7 @@ High-Level Design: Grafana to Chart.js Renderer
 
 This document outlines the high-level design for a TypeScript library that parses a Grafana dashboard JSON file and renders its panels using Chart.js and the chartjs-plugin-datasource-prometheus plugin.
 
-The primary goal is to create a framework-agnostic core engine with a pluggable architecture for UI framework integration. The initial release will target SvelteKit, with the design allowing for future expansion to frameworks like React, Vue, and Angular.
+The primary goal is to create a framework-agnostic core engine with a pluggable architecture for UI framework integration. The initial release targets SvelteKit and React, with the design allowing for future expansion to frameworks like Vue and Angular.
 
 2. Goals & Objectives
 
@@ -24,10 +24,10 @@ The system will be designed with a layered architecture to ensure separation of 
 
 ```
 +------------------------------------------------------+
-|             Application (e.g., SvelteKit)            |
+|          Application (e.g., SvelteKit, React)        |
 +------------------------------------------------------+
 |                 Framework Adapter                    |
-|                (e.g., Svelte Action/Component)       |
+|           (e.g., Svelte or React Component)          |
 +------------------------------------------------------+
 |                  Core Rendering Engine               |
 |                                                      |
@@ -58,13 +58,15 @@ This is the heart of the library, published as a standalone package. It will hav
 
 These are thin, separate packages that make the core engine easy to use within a specific UI framework.
 
-*    SvelteKit Adapter (Initial Target): This will likely be implemented as a Svelte Action (use:grafanaDashboard) or a component (<GrafanaPanel>). It will handle creating the <canvas> element, passing it to the core engine, and cleaning up the chart instance when the component is destroyed.
+*    SvelteKit Adapter: This is implemented as a Svelte component (`<GrafanaPanel>`). It handles creating the `<canvas>` element, passing it to the core engine, and cleaning up the chart instance when the component is destroyed.
+
+*    React Adapter: This is implemented as a React component (`<GrafanaPanel>`). It also handles the `<canvas>` element creation and lifecycle, integrating with React's component lifecycle.
 
 4. Data Flow
 
-*    Initialization: The user's application (e.g., a SvelteKit page) imports the SvelteKit adapter.
+*    Initialization: The user's application (e.g., a SvelteKit or React page) imports the appropriate framework adapter.
 
-*    Component Mount: The Svelte component mounts. It receives the Grafana JSON as a prop.
+*    Component Mount: The Svelte or React component mounts. It receives the Grafana JSON as a prop.
 
 *    Invocation: The adapter creates a <canvas> element, instantiates a GrafanaRenderer with the canvas and options, then calls the render method with the panel JSON.
 
@@ -133,6 +135,28 @@ class GrafanaRenderer {
 </div>
 ```
 
+### React Adapter API
+
+```tsx
+// As a component
+import { GrafanaPanel } from '@leafcuttr/libgraphit-react';
+import dashboard from './my-dashboard.json';
+
+const panel = dashboard.panels[0];
+const options = {
+  prometheusUrl: 'http://localhost:9090',
+  theme: 'light'
+};
+
+function MyChart() {
+  return (
+    <div className="chart-container">
+      <GrafanaPanel panelJson={panel} {...options} />
+    </div>
+  );
+}
+```
+
 6. Constraints & Assumptions (v1.0)
 
 *    Single Datasource: The entire dashboard is assumed to use a single, globally defined Prometheus datasource. The URL for this will be passed during initialization.
@@ -149,7 +173,7 @@ class GrafanaRenderer {
 
 *    Support for Grafana template variables.
 
-*    Adapters for React, Vue, and Angular.
+*    Adapters for Vue and Angular.
 
 *    Interactive features (e.g., legend toggling, cross-hair synchronization).
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,114 @@
+# @leafcuttr/libgraphit-react
+
+React adapter for the Grafana Chart.js Renderer.
+
+## Installation
+
+```bash
+npm install @leafcuttr/libgraphit-react @leafcuttr/libgraphit-core chart.js chartjs-plugin-datasource-prometheus chartjs-adapter-date-fns date-fns
+```
+
+## Usage
+
+This package provides two ways to render Grafana visualizations:
+
+1.  **[`<GrafanaDashboard>`](#grafanadashboard-component)**: A component that renders an entire Grafana dashboard with a grid layout.
+2.  **[`<GrafanaPanel>`](#grafanapanel-component)**: A component for rendering a single Grafana panel.
+
+---
+
+### `<GrafanaDashboard>` Component
+
+This component renders a full Grafana dashboard, including its grid layout.
+
+**Usage**
+
+```tsx
+import { GrafanaDashboard } from '@leafcuttr/libgraphit-react';
+import type { GrafanaDashboard as GrafanaDashboardType } from '@leafcuttr/libgraphit-core';
+import dashboardData from './my-dashboard.json';
+
+function App() {
+  return (
+    <GrafanaDashboard
+      dashboardJson={dashboardData as GrafanaDashboardType}
+      prometheusUrl="http://localhost:9090"
+      theme="dark"
+    />
+  );
+}
+```
+
+---
+
+### `<GrafanaPanel>` Component
+
+This component renders a single Grafana panel.
+
+**Usage**
+
+```tsx
+import { GrafanaPanel } from '@leafcuttr/libgraphit-react';
+import type { Panel } from '@leafcuttr/libgraphit-core';
+import panelData from './my-panel.json';
+
+function App() {
+  return (
+    <GrafanaPanel
+      panelJson={panelData as Panel}
+      prometheusUrl="http://localhost:9090"
+      theme="light"
+      width="100%"
+      height="400px"
+    />
+  );
+}
+```
+
+---
+
+## Component Props
+
+### `<GrafanaDashboard>`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `dashboardJson` | `GrafanaDashboard` | required | The Grafana dashboard JSON object. |
+| `prometheusUrl` | `string` | required | URL of the Prometheus server. |
+| `timeRange` | `{ start: number, end: number }` | `undefined` | Time range for queries. If not provided, it's inferred from the dashboard JSON. |
+| `theme` | `'light' \| 'dark'` | `'light'` | Chart theme. |
+| `refreshInterval` | `number` | `undefined` | Auto-refresh interval in milliseconds. |
+| `queryHandler` | `QueryHandler` | `undefined` | A custom function to handle data fetching. |
+| `className` | `string` | `''` | Additional CSS classes for the container. |
+
+### `<GrafanaPanel>`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `panelJson` | `Panel` | required | The Grafana panel JSON configuration |
+| `prometheusUrl` | `string` | required | URL of the Prometheus server |
+| `timeRange` | `{from: string, to: string}` | `undefined` | Time range for queries |
+| `theme` | `'light' \| 'dark'` | `'light'` | Chart theme |
+| `refreshInterval` | `number` | `undefined` | Auto-refresh interval in milliseconds |
+| `width` | `string` | `'100%'` | Chart container width |
+| `height` | `string` | `'400px'` | Chart container height |
+| `className` | `string` | `''` | Additional CSS classes |
+
+## CSS Custom Properties
+
+The component supports CSS custom properties for theming:
+
+```css
+.my-chart {
+  --bg-color: #ffffff;
+  --border-color: #e0e0e0;
+  --text-color: #333333;
+  --text-muted: #6c757d;
+  --accent-color: #007bff;
+  --error-color: #dc3545;
+}
+```
+
+## License
+
+MIT


### PR DESCRIPTION
This commit updates the project's documentation to reflect the newly added support for React.

- The main `README.md` is updated to include installation instructions and usage examples for the React components (`<GrafanaDashboard>` and `<GrafanaPanel>`).
- The `docs/HighlevelDesign.md` is updated to mention the React adapter and remove it from the "Future Enhancements" section.
- A new `README.md` is created for the `@leafcuttr/libgraphit-react` package, providing specific details and usage examples for the React components.